### PR TITLE
feat: Finalize data collection module

### DIFF
--- a/gotothemoon/datacollector/runner.py
+++ b/gotothemoon/datacollector/runner.py
@@ -1,0 +1,180 @@
+import json
+import os
+from collections import defaultdict
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Dict
+
+from gotothemoon.datacollector.schemas import BaseSchema
+from gotothemoon.datacollector.sources.kr_dart import DartCollector
+from gotothemoon.datacollector.sources.us_edgar import EdgarCollector
+from gotothemoon.datacollector.sources.news_collector import NewsCollector
+from gotothemoon.datacollector.sources.research_collector import ResearchCollector
+
+# --- Approved News Sources ---
+KR_NEWS_SOURCES = [
+    "news.naver.com", "news.daum.net", "chosun.com", "joongang.co.kr",
+    "donga.com", "hani.co.kr", "mk.co.kr", "hankyung.com", "yonhapnews.co.kr", "ytn.co.kr"
+]
+
+US_NEWS_SOURCES = [
+    "nytimes.com", "wsj.com", "washingtonpost.com", "cnn.com", "foxnews.com",
+    "msnbc.com", "abcnews.go.com", "cbsnews.com", "nbcnews.com", "apnews.com",
+    "reuters.com", "bloomberg.com", "cnbc.com", "usatoday.com", "npr.org",
+    "latimes.com", "chicagotribune.com", "forbes.com", "businessinsider.com", "marketwatch.com"
+]
+
+
+def save_data(data: List[BaseSchema], base_data_path: Path):
+    """
+    Saves a list of data schemas to JSON files, organized by year, month,
+    day, and category.
+    """
+    if not data:
+        return
+
+    # Group data by date, country, and category for file organization
+    grouped_data: Dict[str, Dict[str, List]] = defaultdict(list)
+
+    for item in data:
+        try:
+            # Handle multiple date formats to get a datetime object
+            if not item.published_at: continue
+
+            dt_obj = None
+            if "Z" in item.published_at:
+                dt_obj = datetime.fromisoformat(item.published_at.replace("Z", "+00:00"))
+            elif "GMT" in item.published_at:
+                 dt_obj = datetime.strptime(item.published_at, '%a, %d %b %Y %H:%M:%S %Z')
+            else: # Assume YYYY-MM-DD
+                dt_obj = datetime.fromisoformat(item.published_at)
+
+            # Define path and group key
+            year, month, day = str(dt_obj.year), f"{dt_obj.month:02d}", f"{dt_obj.day:02d}"
+            group_key = (year, month, day, item.country, item.category)
+            grouped_data[group_key].append(asdict(item))
+
+        except Exception as e:
+            print(f"Could not process item {item.id} with date '{item.published_at}'. Skipping. Error: {e}")
+            continue
+
+    # Write each group to a separate file
+    for (year, month, day, country, category), records in grouped_data.items():
+        storage_path = base_data_path / year / month / day
+        storage_path.mkdir(parents=True, exist_ok=True)
+
+        # Each file will contain records for one category for one day
+        file_path = storage_path / f"{country}-{category}.json"
+
+        print(f"Saving {len(records)} records to {file_path}")
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(records, f, ensure_ascii=False, indent=4)
+
+
+def run_disclosure_collectors(start_date: str, end_date: str) -> List[BaseSchema]:
+    """Runs all implemented disclosure collectors."""
+    all_data: List[BaseSchema] = []
+    # --- Run KR DART Collector ---
+    print("\n" + "="*50)
+    print("--- Running KR DART Collector ---")
+    if os.getenv("DART_API_KEY"):
+        try:
+            collector = DartCollector()
+            start_dart = start_date.replace('-', '')
+            end_dart = end_date.replace('-', '')
+            all_data.extend(collector.fetch_disclosures(start_dart, end_dart))
+        except Exception as e:
+            print(f"Failed to run DART collector: {e}")
+    else:
+        print("Skipping DART collector: DART_API_KEY not set.")
+    print("="*50 + "\n")
+
+    # --- Run US EDGAR Collector ---
+    print("\n" + "="*50)
+    print("--- Running US EDGAR Collector ---")
+    try:
+        collector = EdgarCollector()
+        all_data.extend(collector.fetch_disclosures(start_date, end_date))
+    except Exception as e:
+        print(f"Failed to run EDGAR collector: {e}")
+    print("="*50 + "\n")
+    return all_data
+
+
+def run_news_collectors(start_date: datetime, end_date: datetime) -> List[BaseSchema]:
+    """Runs all implemented news collectors."""
+    all_data: List[BaseSchema] = []
+    collector = NewsCollector()
+
+    # --- Run US News Collector ---
+    all_data.extend(collector.fetch_news(
+        country_code='US',
+        start_date=start_date,
+        end_date=end_date,
+        news_sources=US_NEWS_SOURCES,
+        max_articles_per_day=10 # Limit to 10 per source for this run
+    ))
+
+    # --- Run KR News Collector ---
+    all_data.extend(collector.fetch_news(
+        country_code='KR',
+        start_date=start_date,
+        end_date=end_date,
+        news_sources=KR_NEWS_SOURCES,
+        max_articles_per_day=10 # Limit to 10 per source for this run
+    ))
+    return all_data
+
+def run_research_collector() -> List[BaseSchema]:
+    """Runs the research data collector."""
+    all_data: List[BaseSchema] = []
+    print("\n" + "="*50)
+    print("--- Running Research Collector ---")
+    if os.getenv("FINNHUB_API_KEY"):
+        try:
+            collector = ResearchCollector()
+            all_data.extend(collector.fetch_research())
+        except Exception as e:
+            print(f"Failed to run Research collector: {e}")
+    else:
+        print("Skipping Research collector: FINNHUB_API_KEY not set.")
+    print("="*50 + "\n")
+    return all_data
+
+
+if __name__ == '__main__':
+    DAYS_TO_FETCH = 2 # Keep it short for testing
+
+    end_dt = datetime.now()
+    start_dt = end_dt - timedelta(days=DAYS_TO_FETCH)
+    start_date_str = start_dt.strftime('%Y-%m-%d')
+    end_date_str = end_dt.strftime('%Y-%m-%d')
+
+    print(f"--- Starting Data Collection Runner ---")
+    print(f"Fetching data from {start_date_str} to {end_date_str}")
+
+    # Set the base path to a top-level 'data' directory
+    base_data_path = Path(__file__).parent.parent.parent / 'data'
+    all_collected_data = []
+
+    # Run Disclosure Collectors
+    disclosure_data = run_disclosure_collectors(start_date=start_date_str, end_date=end_date_str)
+    all_collected_data.extend(disclosure_data)
+
+    # Run News Collectors
+    news_data = run_news_collectors(start_date=start_dt, end_date=end_dt)
+    all_collected_data.extend(news_data)
+
+    # Run Research Collector
+    research_data = run_research_collector()
+    all_collected_data.extend(research_data)
+
+    # --- Save all collected data ---
+    if all_collected_data:
+        print(f"\nTotal items collected across all sources: {len(all_collected_data)}. Saving data...")
+        save_data(all_collected_data, base_data_path)
+    else:
+        print("\nNo data collected.")
+
+    print("\n--- Data Collection Runner Finished ---")

--- a/gotothemoon/datacollector/sources/kr_dart.py
+++ b/gotothemoon/datacollector/sources/kr_dart.py
@@ -1,0 +1,127 @@
+import os
+import time
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import pandas as pd
+from pykrx import stock
+import OpenDartReader
+
+from gotothemoon.datacollector.schemas import DisclosureSchema
+
+
+class DartCollector:
+    """
+    Collects public company disclosures from the DART (Data Analysis, Retrieval and
+    Transfer System) of South Korea's Financial Supervisory Service (FSS).
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initializes the DartCollector.
+
+        Args:
+            api_key (str, optional): The DART API key. If not provided, it will
+                                     be read from the DART_API_KEY environment
+                                     variable.
+        """
+        self.api_key = api_key or os.getenv("DART_API_KEY")
+        if not self.api_key:
+            raise ValueError("DART API key is required. Please provide it or set the DART_API_KEY environment variable.")
+        self.dart = OpenDartReader(self.api_key)
+
+    def _get_target_tickers(self) -> List[str]:
+        """
+        Gets a list of all tickers for KOSPI and KOSDAQ listed companies.
+
+        Returns:
+            List[str]: A list of stock tickers.
+        """
+        print("Fetching all KOSPI and KOSDAQ tickers...")
+        kospi_tickers = stock.get_market_ticker_list(market="KOSPI")
+        kosdaq_tickers = stock.get_market_ticker_list(market="KOSDAQ")
+        all_tickers = list(set(kospi_tickers + kosdaq_tickers))
+        print(f"Found {len(all_tickers)} unique tickers.")
+        return all_tickers
+
+    def fetch_disclosures(self, start_date: str, end_date: str) -> List[DisclosureSchema]:
+        """
+        Fetches all public disclosures for KOSPI and KOSDAQ companies within a
+        given date range.
+
+        Args:
+            start_date (str): The start date in 'YYYYMMDD' format.
+            end_date (str): The end date in 'YYYYMMDD' format.
+
+        Returns:
+            List[DisclosureSchema]: A list of disclosure data objects.
+        """
+        all_disclosures: List[DisclosureSchema] = []
+
+        # DART API can search for all companies at once.
+        # The API is more efficient when querying by date range for all companies
+        # rather than iterating through each company.
+        print(f"Fetching all disclosures from {start_date} to {end_date}...")
+        try:
+            # kind='A' is for regular disclosures (정기공시)
+            df = self.dart.list(start=start_date, end=end_date, kind='A', final=True)
+            if df is None or df.empty:
+                print("No disclosures found for the given period.")
+                return []
+
+            for _, row in df.iterrows():
+                disclosure = DisclosureSchema(
+                    id=row.get('rcept_no', ''),
+                    source='DART',
+                    country='KR',
+                    report_title=row.get('report_nm', ''),
+                    company_name=row.get('corp_name', ''),
+                    company_symbol=row.get('stock_code', ''),
+                    url_to_document=row.get('rcept_url', ''),
+                    filing_type=row.get('report_nm', ''), # Using report_nm as filing_type
+                    published_at=pd.to_datetime(row.get('rcept_dt', '')).isoformat(),
+                )
+                all_disclosures.append(disclosure)
+
+        except Exception as e:
+            print(f"An error occurred while fetching disclosures: {e}")
+
+        print(f"Successfully collected {len(all_disclosures)} disclosures.")
+        return all_disclosures
+
+
+if __name__ == '__main__':
+    print("--- Running DART Collector Example ---")
+
+    # IMPORTANT: To run this example, you must have your DART API key set as an
+    # environment variable.
+    # On Linux/macOS: export DART_API_KEY='your_api_key_here'
+    # On Windows: set DART_API_KEY='your_api_key_here'
+
+    if not os.getenv("DART_API_KEY"):
+        print("\nERROR: DART_API_KEY environment variable not set.")
+        print("Please set it to your API key to run this example.")
+    else:
+        print(f"Using DART API key found in environment.")
+        collector = DartCollector()
+
+        # Fetch disclosures for the last 3 days as a test
+        end_dt = datetime.now()
+        start_dt = end_dt - timedelta(days=3)
+        start_date_str = start_dt.strftime('%Y%m%d')
+        end_date_str = end_dt.strftime('%Y%m%d')
+
+        print(f"\nFetching disclosures from {start_date_str} to {end_date_str}...")
+        disclosures = collector.fetch_disclosures(start_date=start_date_str, end_date=end_date_str)
+
+        if disclosures:
+            print(f"\nSuccessfully fetched {len(disclosures)} disclosures.")
+            print("--- First 3 Disclosures ---")
+            for i, disclosure in enumerate(disclosures[:3]):
+                print(f"[{i+1}] {disclosure.company_name} ({disclosure.company_symbol}) - {disclosure.report_title}")
+                print(f"  - Published: {disclosure.published_at}")
+                print(f"  - URL: {disclosure.url_to_document}")
+        else:
+            print("\nNo disclosures found in the last 3 days.")
+
+    print("\n--- DART Collector Example Finished ---")

--- a/gotothemoon/datacollector/utils/tickers.py
+++ b/gotothemoon/datacollector/utils/tickers.py
@@ -1,0 +1,50 @@
+from typing import List
+import requests
+from bs4 import BeautifulSoup
+from pykrx import stock
+
+def _scrape_wiki_tickers(url: str, table_index: int, symbol_col: int, user_agent: str) -> List[str]:
+    """Helper to scrape tickers from a Wikipedia table."""
+    try:
+        resp = requests.get(url, headers={'User-Agent': user_agent})
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        table = soup.find_all('table', {'class': 'wikitable'})[table_index]
+        tickers = []
+        for row in table.find_all('tr')[1:]:
+            ticker = row.find_all('td')[symbol_col].text.strip()
+            tickers.append(ticker)
+        return tickers
+    except Exception as e:
+        print(f"Could not scrape tickers from {url}. Error: {e}")
+        return []
+
+def get_us_tickers(user_agent: str = "GoToTheMoon Project/1.0") -> List[str]:
+    """
+    Gets a combined list of S&P 500 and NASDAQ-100 tickers.
+    """
+    print("Fetching S&P 500 tickers...")
+    sp500 = _scrape_wiki_tickers(
+        'https://en.wikipedia.org/wiki/List_of_S%26P_500_companies', 0, 0, user_agent
+    )
+    print("Fetching NASDAQ-100 tickers...")
+    nasdaq100 = _scrape_wiki_tickers(
+        'https://en.wikipedia.org/wiki/Nasdaq-100', 4, 1, user_agent
+    )
+
+    all_tickers = sorted(list(set(sp500 + nasdaq100)))
+    print(f"Found {len(all_tickers)} unique US tickers.")
+    # Replace dots with dashes for tickers like 'BRK.B' -> 'BRK-B' for some APIs
+    all_tickers = [ticker.replace('.', '-') for ticker in all_tickers]
+    return all_tickers
+
+def get_kr_tickers() -> List[str]:
+    """
+    Gets a list of all tickers for KOSPI and KOSDAQ listed companies.
+    """
+    print("Fetching all KOSPI and KOSDAQ tickers...")
+    kospi_tickers = stock.get_market_ticker_list(market="KOSPI")
+    kosdaq_tickers = stock.get_market_ticker_list(market="KOSDAQ")
+    all_tickers = sorted(list(set(kospi_tickers + kosdaq_tickers)))
+    print(f"Found {len(all_tickers)} unique KR tickers.")
+    return all_tickers


### PR DESCRIPTION
This commit finalizes the data collection module. It includes collectors for news, public disclosures, and analyst research for both the US and South Korea.

The main runner script is configured to use these collectors and save the data in a structured directory format (`data/year/month/day/country-category.json`) as you requested.

I tried to run the collection script to generate sample data, but my attempts failed due to persistent timeout issues. I believe the code itself is correct and should run successfully in a stable environment.